### PR TITLE
Use openssl hashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-sha1 = "0.6.0"
-sha2 = "0.9.2"
 xattr = "0.2.2"
 openssl = "0.10.31"
 libc = "0.2"

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -1,52 +1,25 @@
 use crate::HashAlgo;
 
-use anyhow::{bail, Context, Result};
-use sha1::Sha1;
-use sha2::{Digest, Sha256};
+use std::convert::TryInto;
+
+use anyhow::{Context, Result};
+use openssl::hash::hash;
 
 mod keyutils;
 use keyutils::Key;
 
-fn sign_digest(
-    signkey: &Key,
-    hash_algo: &HashAlgo,
-    digest: &[u8],
-    siglen: usize,
-) -> Result<Vec<u8>> {
-    let mut signature = signkey
-        .sign(hash_algo, digest)
-        .with_context(|| "Error signing data".to_string())?;
+pub(crate) fn hash_and_sign(signkey: &Key, hash_algo: &HashAlgo, data: &[u8]) -> Result<Vec<u8>> {
+    let digest = hash(
+        hash_algo
+            .try_into()
+            .with_context(|| "Unable to determine message digest".to_string())?,
+        data,
+    )
+    .with_context(|| "Error hashing message".to_string())?;
 
-    // https://github.com/mathstuf/rust-keyutils/pull/55
-    unsafe {
-        // This is equal to the number of bytes in the key
-        signature.set_len(siglen);
-    }
-
-    Ok(signature)
-}
-
-pub(crate) fn hash_and_sign(
-    signkey: &Key,
-    hash_algo: &HashAlgo,
-    data: &[u8],
-    siglen: usize,
-) -> Result<Vec<u8>> {
-    let digest = match hash_algo {
-        HashAlgo::Sha1 => {
-            let mut hasher = Sha1::new();
-            hasher.update(&data);
-            hasher.digest().bytes().to_vec()
-        }
-        HashAlgo::Sha256 => {
-            let mut hasher = Sha256::new();
-            hasher.update(&data);
-            hasher.finalize().as_slice().to_vec()
-        }
-        _ => bail!("Unsupported hash algorithm {:?} selected", hash_algo),
-    };
-
-    sign_digest(signkey, hash_algo, &digest, siglen)
+    signkey
+        .sign(hash_algo, &digest)
+        .with_context(|| "Error signing data".to_string())
 }
 
 pub(crate) fn get_signing_key(description: &str) -> Result<Key> {


### PR DESCRIPTION
This helps get rid of the sha1 and sha256 dependencies.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>